### PR TITLE
Fix Abjad dead website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Thanks to all [contributors](https://github.com/ciconia/awesome-music/graphs/con
 
 ## Music Notation
 
-* [Abjad](http://projectabjad.org/) - a Python API for Formalized Score Control, based on Lilypond.
+* [Abjad](http://abjad.mbrsi.org/) - a Python API for Formalized Score Control, based on Lilypond.
 * [Denemo](http://www.denemo.org/) - a free music notation editor based on Lilypond.
 * [Jan Angermüller's music fonts page](http://elbsound.studio/music_fonts.php) - A listing and visual comparison of different music fonts.
 * [Frescobaldi](https://github.com/wbsoft/frescobaldi) - a free Lilypond sheet music editor.


### PR DESCRIPTION
The Abjad python lib link is broken, after googling, I found [this](http://abjad.mbrsi.org/) website that seems like the official one and has links to everything related to Abjad.