### PR TITLE
Adding Sardine, a live coding library

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Thanks to all [contributors](https://github.com/ciconia/awesome-music/graphs/con
 * [Platonic Music Engine](http://www.platonicmusicengine.com/) - an open-source music generation framework written in Lua.
 * [Pure Data](http://puredata.info/) - a visual programming language for audio and other multimedia.
 * [py-modular](http://py-modular.readthedocs.io/) - a modular and experimental programming environment with basic DSP routines in python.
+* [Sardine](https://github.com/Bubobubobubobubo/sardine) - a music live coding library for Python 3.10+ (MIDI/OSC/SuperCollider).
 * [Sonic Pi](http://sonic-pi.net/) - a live coding synth with an emphasis on educational use.
 * [Sporth](https://pbat.ch/proj/sporth.html) - a small stack based audio language.
 * [SuperCollider](http://supercollider.github.io/) - a programming language for real time audio synthesis and algorithmic composition.


### PR DESCRIPTION
This commit is adding Sardine, a documented and maintained music live coding library for Python 3.10+.