### PR TITLE
Drop no-longer maintained tunefl

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ Thanks to all [contributors](https://github.com/ciconia/awesome-music/graphs/con
 * [Ripple](https://github.com/ciconia/ripple/) - DRY for Lilypond - generate scores and parts with minimal fuss.
 * [Scorelib](http://scorelib.sapp.org/) - a C++ library for parsing SCORE data files.
 * [Tbon](https://github.com/Michael-F-Ellis/tbon) - Typographic Beat-Oriented Notation for music.
-* [Tunefl](https://github.com/tiredpixel/tunefl) - LilyPond mini-score engraving and sharing service for musicians.
 * [Unison](https://unisonofficial.com/html/user-documentation.html?title=unison-editor) - Proprietary software for creating music score with words.
 * [Verovio](https://github.com/rism-ch/verovio) - a library and a toolkit for engraving MEI music notation into SVG.
 * [Vexflow](https://github.com/0xfe/vexflow) - a JavaScript library for rendering music notation and guitar tablature.


### PR DESCRIPTION
Tunefl seems to be no longer maintained since 2016 [1], I think it should therefore be dropped from this list.

[1] https://github.com/tiredpixel/z.2016-01-19.tunefl