### PR TITLE
Drop no-longer maintained i-score

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Thanks to all [contributors](https://github.com/ciconia/awesome-music/graphs/con
 * [Frescobaldi](https://github.com/wbsoft/frescobaldi) - a free Lilypond sheet music editor.
 * [Guido](http://guidolib.sourceforge.net/) - a generic, portable library and API for the graphical rendering of musical scores.
 * [Hacklily](https://www.hacklily.org) - online LilyPond-based sheet music editor (with optional GitHub integration).
-* [i-score](http://www.i-score.org) - a software for interactive music notation, with DAW features.
 * [Inknote](https://github.com/MichalPaszkiewicz/inknote) - free, open source, browser based music notation and composition software.
 * [LibMEI](https://github.com/DDMAL/libmei) - a C++ library for reading and writing MEI files.
 * [Lilybin](http://lilybin.com/) - an open source web-based LilyPond editor.


### PR DESCRIPTION
The webpage is without any content [1]. The latest commit is 8 years ago [2]. I think most people would prefer upstream 'ossia/score' nowadays [3]. I also think the category 'Music Notation' doesn't fit, as ossia scores concept of 'score' isn't about Western music notation, but more 'a sequencer for audio-visual artists'.

[1] http://i-score.org/
[2] https://github.com/rperrot/i-score
[3] https://github.com/ossia/score