### PR TITLE
Add mei-friend description

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Thanks to all [contributors](https://github.com/ciconia/awesome-music/graphs/con
 * [Lilyvm](https://github.com/olsonpm/lilyvm) - Lilypond version manager.
 * [Lydown](https://github.com/ciconia/lydown) - a modern language for music notation, based on Lilypond.
 * [Lyp](https://github.com/noteflakes/lyp) - the Lilypond swiss army knife - easily install packages, manage multiple versions of Lilypond, and other tools for power users.
+* [mei-friend](https://mei-friend.mdw.ac.at) - a friendly, browser-based editor for music encodings.
 * [MuseScore](https://github.com/musescore/MuseScore) - free open-source music notation and composition software.
 * [MusicKit](https://github.com/venturemedia/musickit) - Music sheet rendering for iOS and OSX.
 * [neoscore](https://neoscore.org/) - python library for notating music in a graphics-first paradigm.


### PR DESCRIPTION
This PR adds a link to mei-friend, a browser-based graphical music encoding editor. It is capable of opening encodings in a variety of formats, but converts them to MEI, the format of the [Music Encoding Initiative](https://mei-friend.mdw.ac.at/) for editing. The editor supports a number of basic and advanced features, documented at https://mei-friend.github.io/. The browser is open-source and community developed, and widely used by members of the MEI, counting typically more than 500 unique user sessions a month at its official instance hosted by mdw - University of Music and Performing Arts Vienna.