### PR TITLE
Add Auralytics: An open-source personal Spotify analytics tool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Thanks to all [contributors](https://github.com/ciconia/awesome-music/graphs/con
 
 ## Audio Tools
 
+* [Auralytics](https://github.com/WengYiNing/Auralytics) - an open-source personal Spotify analytics tool.
 * [Beets](http://beets.io/) - a powerful command-line music organizer and manipulator.
 * [Cecilia](https://github.com/belangeo/cecilia5) - a Pyo-based graphical environment for music and signal processing.
 * [cyanrip](https://github.com/atomnuker/cyanrip) - rips and encodes standard audio CDs with the least effort required from user. Cross platform.


### PR DESCRIPTION
This PR adds [Auralytics](https://github.com/WengYiNing/Auralytics) to the Audio Tools section. 

- Description: An open-source personal Spotify analytics tool. 
- Added under the correct category (Audio Tools). 
- Entry is in alphabetical order. 
- Single link only, no tracking. 
- Project has license, active maintenance, and contribution guidelines. 

Thank you for considering!