### PR TITLE
Add PracticeLoop to Music Theory Teaching

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Thanks to all [contributors](https://github.com/ciconia/awesome-music/graphs/con
 * [musictheory.net](https://www.musictheory.net) - Lessons and exercises
 * [OpenMusicTheory](http://openmusictheory.com/) - a growing, online "textbook" for music theory and aural skills.
 * [Theorytab](https://www.hooktheory.com/theorytab) - a database of songs with their chord functions.
+* [PracticeLoop](https://teal-semifreddo-cad4ad.netlify.app/) - Free web tool for slowing down and looping YouTube videos for music practice, with progressive speed training and built-in metronome.
 
 ## Standards
 


### PR DESCRIPTION
Adds PracticeLoop, a free web tool for musicians to practice difficult passages by slowing down and looping YouTube videos.

Key features:
- Speed control (0.25x-2x) with 4 presets
- A-B loop with keyboard shortcuts
- Progressive speed training (auto-increment after N loop reps)
- Built-in metronome with tap tempo
- Practice timer with session tracking and streaks
- PWA support (add to home screen)
- Instrument-specific landing pages (guitar, bass, piano, drums, violin)

Fits well in Music Theory Teaching section alongside other interactive learning tools.