### PR TITLE
Add audio-transcode-watcher to Audio Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Thanks to all [contributors](https://github.com/ciconia/awesome-music/graphs/con
 
 ## Audio Tools
 
+* [audio-transcode-watcher](https://github.com/GeiserX/audio-transcode-watcher) - automated multi-format audio transcoding service with real-time file watching and lyrics fetching.
 * [Auralytics](https://github.com/WengYiNing/Auralytics) - an open-source personal Spotify analytics tool.
 * [Beets](http://beets.io/) - a powerful command-line music organizer and manipulator.
 * [Cecilia](https://github.com/belangeo/cecilia5) - a Pyo-based graphical environment for music and signal processing.


### PR DESCRIPTION
## Summary
- Adds [audio-transcode-watcher](https://github.com/GeiserX/audio-transcode-watcher) to the Audio Tools section
- audio-transcode-watcher is an automated multi-format audio transcoding service with real-time file watching and lyrics fetching
- Entry placed in alphabetical order