### PR TITLE
Add Gingoduino to MIDI Tools & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Thanks to all [contributors](https://github.com/ciconia/awesome-music/graphs/con
 
 ## MIDI Tools & Libraries
 
+* [Gingoduino](https://github.com/sauloverissimo/gingoduino) - music theory engine for embedded systems with MIDI 1.0/2.0 UMP support.
 * [JJazzLab-X](https://github.com/jjazzboss/JJazzLab-X) - a complete Midi-based framework for automatic backing tracks generation.
 * [Midifile](http://midifile.sapp.org/) - C++ library for parsing Standard MIDI Files.
 * [mido](https://github.com/mido/mido) - Python library for working with MIDI messages and ports.


### PR DESCRIPTION
Adds [Gingoduino](https://github.com/sauloverissimo/gingoduino) to MIDI Tools & Libraries.

Gingoduino is a music theory engine for embedded systems (Arduino, ESP32, RP2040, Teensy, Daisy Seed) covering notes, intervals, chords, scales, harmonic fields, harmonic trees, progression analysis, fretboard engines, and a real-time harmonic monitor. Output adapters serialize musical structures to MIDI 1.0 bytes and MIDI 2.0 UMP Flex Data. Zero-heap C++11, PROGMEM lookup tables.

Repository: https://github.com/sauloverissimo/gingoduino
Latest release: https://github.com/sauloverissimo/gingoduino/releases/tag/v0.4.0

Quality standard:
- MIT licensed
- 399 native tests with CI on GitHub Actions, built under -Wall -Wextra -Werror
- 6 releases published, latest v0.4.0 (2026-05-01) with full CHANGELOG and migration guide
- Distributed on Arduino Library Manager, PlatformIO Registry, and ESP-IDF Component Registry
- Documented: README (EN + PT-BR), Wiki, examples (including on-device acceptance suite V04_SelfTest)

Follows CONTRIBUTING.md: single link, alphabetical placement, description ends with a period.