### PR TITLE
Music Notation: add DomiSol (solfa & jianpu score editor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Thanks to all [contributors](https://github.com/ciconia/awesome-music/graphs/con
 * [ChordMark](https://chordmark.netlify.app/) - a text-based notation format for lyrics, chords and rhythm.
 * [Denemo](http://www.denemo.org/) - a free music notation editor based on Lilypond.
 * [Digital Music Stand](https://github.com/PatWie/digitalmusicstand) - a free web app for displaying sheet music.
+* [DomiSol](https://domisol.app) - free web-based score editor for tonic solfa (d r m f s l t) and jianpu (1 2 3 4 5 6 7) notation.
 * [Jan Angermüller's music fonts page](http://elbsound.studio/music_fonts.php) - A listing and visual comparison of different music fonts.
 * [Frescobaldi](https://github.com/wbsoft/frescobaldi) - a free Lilypond sheet music editor.
 * [Guido](http://guidolib.sourceforge.net/) - a generic, portable library and API for the graphical rendering of musical scores.


### PR DESCRIPTION
Adding DomiSol under **Music Notation**.

DomiSol is a free, web-based score editor where tonic solfa (`d r m f s l t`) and jianpu (`1 2 3 4 5 6 7`) are the editing model, not export formats. The two notations cover audiences staff-notation editors generally underserve: African church choirs and Chinese / Taiwanese / Indonesian musicians whose first reading language is solfa or numbered notation.

- URL: https://domisol.app
- Free during public beta
- One-click toggle between solfa and jianpu on any score
- SATB, lyric alignment, PDF export, share-via-URL viewer
- Built with Astro + Firebase + Tone.js

Inserted alphabetically after "Digital Music Stand" with the same single-line bullet format used by neighbouring entries.